### PR TITLE
Change the way active packages are handled

### DIFF
--- a/library.dylan
+++ b/library.dylan
@@ -74,14 +74,14 @@ define module workspaces
     import: { err, iff, inc!, slice };
 
   export
-    find-workspace,
+    load-workspace,
     <workspace>,
       active-package-directory,
       active-package-file,
       active-package?,
       workspace-active-packages,
       workspace-directory,
-      workspace-file,
+      find-workspace-file,
       workspace-default-library-name,
     new,
     update,

--- a/tests/workspaces-tests.dylan
+++ b/tests/workspaces-tests.dylan
@@ -5,15 +5,13 @@ define test test-new ()
   let ws-dir = subdirectory-locator(test-dir, "workspace-1");
   let ws-file = merge-locators(as(<file-locator>, "workspace.json"), ws-dir);
   assert-false(fs/file-exists?(ws-dir));
-  ws/new("workspace-1", #["pkg-1", "pkg-2"], parent-directory: test-dir);
+  ws/new("workspace-1", parent-directory: test-dir);
   assert-true(fs/file-exists?(ws-file));
 
   let dict = fs/with-open-file(stream = ws-file)
-               json/parse(stream)
+               json/parse(stream, strict?: #f)
              end;
-  assert-true(dict["active"]);
-  assert-true(dict["active"]["pkg-1"]);
-  assert-true(dict["active"]["pkg-2"]);
+  assert-true(empty?(dict));
 end test;
 
 run-test-application();

--- a/workspaces.dylan
+++ b/workspaces.dylan
@@ -19,57 +19,43 @@ end function;
 
 define constant $workspace-file = "workspace.json";
 define constant $default-library-key = "default-library";
-define constant $active-key = "active";
 
-define function str-parser (s :: <string>) => (s :: <string>) s end;
-
-// Pulled out into a constant because it ruins code formatting.
-define constant $workspace-file-format-string
-  = #:str:[{
-    %=: {
-%s
-    }
-}
-];
-
-// Create a new workspace named `name` with active packages `pkg-names`.
+// Create a new workspace named `name` under `parent-directory`. If `parent-directory` is
+// not supplied use the standard location.
+//
+// TODO: validate `name`
 define function new
-    (name :: <string>, pkg-names :: <seq>,
-     #key parent-directory :: <directory-locator> = fs/working-directory(),
-          skip-workspace-check? :: <bool>)
-  let check? = ~skip-workspace-check?;
-  let file = check? & workspace-file(directory: parent-directory);
-  if (file & check?)
-    workspace-error("You appear to already be in a workspace directory: %s", file);
-  end;
-  let ws-dir = subdirectory-locator(parent-directory, name);
-  let ws-file = as(<file-locator>, "workspace.json");
+    (name :: <string>, #key parent-directory :: false-or(<directory-locator>))
+ => (w :: false-or(<workspace>))
+  let dir = parent-directory | fs/working-directory();
+  let ws-dir = subdirectory-locator(dir, name);
+  let ws-file = as(<file-locator>, $workspace-file);
   let ws-path = merge-locators(ws-file, ws-dir);
-  if (fs/file-exists?(ws-dir))
-    workspace-error("Directory already exists: %s", ws-dir);
+  let existing = find-workspace-file(dir);
+  if (existing)
+    workspace-error("Can't create workspace file %s because it is inside another"
+                      " workspace, %s.", ws-path, existing);
   end;
-  fs/ensure-directories-exist(ws-path);
-  fs/with-open-file (stream = ws-path,
-                     direction: #"output",
-                     if-does-not-exist: #"create")
-    if (pkg-names.size = 0)
-      pkg-names := #["<package-name-here>"];
-    elseif (pkg-names.size = 1 & pkg-names[0] = "all")
-      pkg-names := as(<vector>, pm/package-names(pm/load-catalog()));
+  if (fs/file-exists?(ws-path))
+    log-info("Workspace already exists: %s", ws-path);
+  else
+    fs/ensure-directories-exist(ws-path);
+    fs/with-open-file (stream = ws-path,
+                       direction: #"output", if-does-not-exist: #"create",
+                       if-exists: #"error")
+      format(stream, "# Dylan workspace %=\n\n{}\n", name);
     end;
-    format(stream, $workspace-file-format-string,
-           $active-key,
-           join(pkg-names, ",\n", key: curry(format-to-string, "        %=: {}")));
+    log-info("Workspace created: %s", ws-path);
   end;
-  log-info("Wrote workspace file to %s.", ws-path);
+  load-workspace(ws-dir)
 end function;
 
 // Update the workspace based on the workspace.json file or signal an error.
 define function update () => ()
-  let ws = find-workspace();
+  let ws = load-workspace(fs/working-directory());
   log-info("Workspace directory is %s.", ws.workspace-directory);
   let cat = pm/load-catalog();
-  update-active-packages(ws, cat);
+  update-deps(ws, cat);
   update-registry(ws, cat);
 end function;
 
@@ -77,8 +63,8 @@ end function;
 // that knows the layout of the workspace directory:
 //       workspace/
 //         _build
-//         active-package-1/
-//         active-package-2/
+//         active-package-1/pkg.json
+//         active-package-2/pkg.json
 //         registry/
 define class <workspace> (<object>)
   constant slot workspace-directory :: <directory-locator>,
@@ -94,58 +80,38 @@ end class;
 // Finds the workspace file somewhere in or above `directory` and creates a
 // `<workspace>` from it. `directory` defaults to the current working
 // directory.  Signals `<workspace-error>` if the file isn't found.
-define function find-workspace
-    (#key directory :: false-or(<directory-locator>)) => (w :: <workspace>)
-  let path = workspace-file();
-  if (~path)
-    workspace-error("Workspace file not found."
-                      " Current directory isn't under a workspace directory?");
-  end;
+define function load-workspace
+    (directory :: <directory-locator>) => (w :: <workspace>)
+  let path = find-workspace-file(directory)
+    | workspace-error("Workspace file not found for %s", directory);
   fs/with-open-file(stream = path, if-does-not-exist: #"signal")
     let object = json/parse(stream, strict?: #f, table-class: <istring-table>);
     if (~instance?(object, <table>))
       workspace-error("Invalid workspace file %s, must be a single JSON object", path);
-    elseif (~element(object, $active-key, default: #f))
-      workspace-error("Invalid workspace file %s, missing required key 'active'", path);
-    elseif (~instance?(object[$active-key], <table>))
-      workspace-error("Invalid workspace file %s, the '%s' element must be a map"
-                        " from package name to {...}.",
-                      $active-key, path);
     end;
-    let registry = make(<registry>, root-directory: locator-directory(path));
-    let active = object[$active-key];
-    let library = element(object, $default-library-key, default: #f);
-    if (~library & active.size = 1)
-      for (_ keyed-by package-name in active)
-        library := package-name;
+    let ws-dir = locator-directory(path);
+    let registry = make(<registry>, root-directory: ws-dir);
+    let active-packages = find-active-packages(ws-dir);
+    let default-library = element(object, $default-library-key, default: #f);
+    if (~default-library & active-packages.size = 1)
+      // TODO: this isn't right. Should find the actual libraries, from the LID
+      // files, and if there's only one "*-test*" library, choose that.
+      for (pkg in active-packages)
+        default-library := pm/package-name(pkg);
       end;
     end;
-    let active-packages
-      = map(method (name)
-              pm/find-package(pm/load-catalog(), name)
-                | make(pm/<package>,
-                       name: name,
-                       releases: #[],
-                       summary: format-to-string("active package %s", name),
-                       description: "unknown",
-                       contact: "unknown",
-                       license-type: "unknown",
-                       category: "unknown")
-            end,
-            key-sequence(object[$active-key])); // nothing in the values yet
     make(<workspace>,
          active-packages: active-packages,
          directory: locator-directory(path),
          registry: registry,
-         default-library-name: library)
+         default-library-name: default-library)
   end
 end function;
 
 // Search up from `directory` to find the workspace file. If `directory` is not
 // supplied it defaults to the current working directory.
-define function workspace-file
-    (#key directory :: <directory-locator> = fs/working-directory())
- => (file :: false-or(<file-locator>))
+define function find-workspace-file
+    (directory :: <directory-locator>) => (file :: false-or(<file-locator>))
   let ws-file = as(<file-locator>, $workspace-file);
   iterate loop (dir = directory)
     if (dir)
@@ -157,6 +123,26 @@ define function workspace-file
       end
     end
   end
+end function;
+
+// Find `directory`/*/pkg.json and turn them into a sequence of package <release>s.
+define function find-active-packages
+    (directory :: <directory-locator>) => (pkgs :: <seq>)
+  let packages = make(<stretchy-vector>);
+  for (locator in fs/directory-contents(directory))
+    if (instance?(locator, <directory-locator>))
+      let loc = merge-locators(as(<file-locator>, "pkg.json"), locator);
+      if (fs/file-exists?(loc))
+        let pkg = pm/read-package-file(loc);
+        if (pkg)
+          add!(packages, pkg);
+        else
+          log-warning("No package found in %s; ignored", loc);
+        end;
+      end;
+    end;
+  end;
+  packages
 end function;
 
 define function active-package-names
@@ -181,37 +167,10 @@ define function active-package?
   member?(pkg-name, ws.active-package-names, test: istring=?)
 end function;
 
-// Download the active packages and all of their resolved dependencies.  If an active
-// package directory doesn't exist, the package is searched for in the catalog and
-// downloaded. If not found, it is skipped with a warning. If the active package
-// directory DOES exist, it is assumed to be current and the package is skipped.
-//
-// TODO(cgay): skipping the directory if it exists is pretty bad but is a start. Need to
-// reload pkg.json, if it exists, and install new deps.
-//
-// We cobble together a fake "root" release to pass to pm/resolve-deps. The fake release
-// has the active packages as its direct dependencies. The reason for doing it this way
-// is to give pm/resolve-deps ALL the necessary info at the same time, including the
-// active packages.
-define function update-active-packages
+// Resolve active package dependencies and install them.
+define function update-deps
     (ws :: <workspace>, cat :: pm/<catalog>)
   let (deps, actives) = find-active-package-deps(ws, cat);
-
-  // Download active packages
-  for (release in actives)
-    let dir = active-package-directory(ws, release.pm/package-name);
-    if (fs/file-exists?(dir))
-      // TODO(cgay): need to load the pkg.json file in case it has been modified, for
-      // example, by adding a new dependency. Then return it so that it can be included
-      // when updating dependencies, which happens all at one time so that conflicting
-      // deps can be detected.
-      log-trace("Active package directory %s exists, not downloading %s.",
-                dir, release.pm/package-name);
-    else
-      pm/download(release, dir);
-    end;
-  end;
-
   // Install dependencies. Note that resolve-deps doesn't return any of the packages
   // passed in `actives`, so all of the following packages will be installed to
   // ${DYLAN}/pkg.


### PR DESCRIPTION
Rather than listing active packages in pkg.json we look for `*/pkg.json` in the
workspace directory. Instead of downloading active packages for the user they
must use `git clone` manually instead. This actually simplifies the workflow
for the user since they already know how to clone repos but don't necessarily
know the format of `workspace.json`.

It also moves towards the package manager being agnostic about which source
control system is in use.

Also renamed find-workspace to load-workspace to better reflect that it loads a
file from disk as opposed to just finding an object in memory.